### PR TITLE
change types of two Annotation attributes, fix #49

### DIFF
--- a/src/crowsetta/annotation.py
+++ b/src/crowsetta/annotation.py
@@ -1,5 +1,8 @@
+from pathlib import Path
+
 import attr
-from attr.validators import optional, instance_of
+from attr import validators, converters
+from attr.validators import instance_of
 
 from .sequence import Sequence
 
@@ -7,6 +10,6 @@ from .sequence import Sequence
 @attr.s
 class Annotation:
     """a class to represent annotations for a single file"""
-    annot_file = attr.ib(validator=instance_of(str))
-    audio_file = attr.ib(validator=optional(instance_of(str)), default=None)
-    seq = attr.ib(validator=optional(instance_of(Sequence)), default=None)
+    annot_file = attr.ib(converter=Path)
+    audio_file = attr.ib(converter=converters.optional(Path), default=None)
+    seq = attr.ib(validator=validators.optional(instance_of(Sequence)), default=None)


### PR DESCRIPTION
+ `Annotation.annot_file` now gets converted to a `pathlib.Path`
  instead of a string. This fixes errors caused by passing it
  a `Path` when the validator specified it should be a string.
+ `Annotation.audio_file` does the same, except that this
  attribute is optional (can be `None`).
+ chose to do this instead of converting `Path`s passed to
  `str`s because in general it's less verbose and more
  explicit to work with `Path` objects and their methods