### PR TITLE
ENH: rename two formats, fix #133

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,13 +47,13 @@ dev = [
 ]
 
 [project.entry-points."crowsetta.format"]
-csv = 'crowsetta.csv'
+generic-seq = 'crowsetta.generic'
 birdsong-recognition-dataset = 'crowsetta.birdsongrec'
 notmat = 'crowsetta.notmat'
 phn = 'crowsetta.phn'
 textgrid = 'crowsetta.textgrid'
 yarden = 'crowsetta.yarden'
-simple-csv = 'crowsetta.simple'
+simple-seq = 'crowsetta.simple'
 
 [project.urls]
 Source = "https://github.com/NickleDave/crowsetta"

--- a/src/crowsetta/__init__.py
+++ b/src/crowsetta/__init__.py
@@ -16,9 +16,9 @@ from .sequence import Sequence
 from .annotation import Annotation
 from .meta import Meta
 from . import (
-    csv,
-    formats,
     birdsongrec,
+    formats,
+    generic,
     notmat,
     phn,
     simple,

--- a/src/crowsetta/birdsongrec.py
+++ b/src/crowsetta/birdsongrec.py
@@ -15,7 +15,7 @@ import soundfile
 
 from .annotation import Annotation
 from .sequence import Sequence
-from . import csv
+from . import generic
 from .meta import Meta
 
 
@@ -155,7 +155,7 @@ def birdsongrec2csv(annot_path, concat_seqs_into_songs=True, wavpath='./Wave',
     if csv_filename is None:
         csv_filename = os.path.abspath(annot_path)
         csv_filename = csv_filename.replace('xml', 'csv')
-    csv.annot2csv(annot, csv_filename, abspath=abspath, basename=basename)
+    generic.annot2csv(annot, csv_filename, abspath=abspath, basename=basename)
 
 
 meta = Meta(

--- a/src/crowsetta/generic.py
+++ b/src/crowsetta/generic.py
@@ -1,4 +1,19 @@
-"""module of functions for handling csv files"""
+"""
+generic format,
+meant to be an abstraction of
+any sequence-like format.
+
+Consists of ``Annotation``s,
+each with a ``Sequence`` made up
+of ``Segment``s.
+
+Functions in this module
+load the format from a .csv,
+or write a .csv in the generic format.
+Other formats that convert to ``Annotation``s
+with ``Sequence``s can be converted
+to this format.
+"""
 import os
 import csv
 
@@ -332,7 +347,7 @@ def csv2annot(csv_filename):
 
 
 meta = Meta(
-    name='csv',
+    name='generic-seq',
     ext='csv',
     from_file=csv2annot,
     to_csv=annot2csv,

--- a/src/crowsetta/notmat.py
+++ b/src/crowsetta/notmat.py
@@ -7,9 +7,9 @@ import numpy as np
 import scipy.io
 import evfuncs
 
+from . import generic
 from .sequence import Sequence
 from .annotation import Annotation
-from .csv import annot2csv
 from .meta import Meta
 from .validation import validate_ext
 
@@ -131,7 +131,7 @@ def notmat2csv(annot_path, csv_filename, abspath=False, basename=False):
                          'information (just base filename) should be saved.')
 
     annot = notmat2annot(annot_path)
-    annot2csv(annot, csv_filename, abspath=abspath, basename=basename)
+    generic.annot2csv(annot, csv_filename, abspath=abspath, basename=basename)
 
 
 def make_notmat(filename,

--- a/src/crowsetta/phn.py
+++ b/src/crowsetta/phn.py
@@ -8,7 +8,7 @@ import soundfile
 
 from .sequence import Sequence
 from .annotation import Annotation
-from .csv import annot2csv
+from . import generic
 from .meta import Meta
 from .validation import validate_ext
 
@@ -153,7 +153,7 @@ def phn2csv(annot_path, csv_filename, abspath=False, basename=False):
                          'information (just base filename) should be saved.')
 
     annot = phn2annot(annot_path)
-    annot2csv(annot, csv_filename, abspath=abspath, basename=basename)
+    generic.annot2csv(annot, csv_filename, abspath=abspath, basename=basename)
 
 
 def annot2phn(annot,

--- a/src/crowsetta/simple.py
+++ b/src/crowsetta/simple.py
@@ -1,13 +1,19 @@
-"""module with functions that handle a simple .csv annotation format"""
+"""
+simple form of a sequence-like format
+
+Assumes that each source file (audio or spectrogram)
+has an annotation in a corresponding .csv file
+with the following header:
+onset_s, offset_s, label
+"""
 import os
 
 import numpy as np
 import pandas as pd
-import scipy.io
 
+from . import generic
 from .sequence import Sequence
 from .annotation import Annotation
-from .csv import annot2csv
 from .meta import Meta
 from .validation import validate_ext
 
@@ -17,8 +23,14 @@ def simple2annot(annot_path,
                  basename=False,
                  round_times=True,
                  decimals=3):
-    """parse annotation from simple .csv files,
+    """parse annotation of sequences from simple .csv files,
     and load into ``crowsetta.Annotation``s
+
+    Assumes that each source file (audio or spectrogram)
+    has an annotation in a corresponding .csv file
+    with the following header:
+    onset_s, offset_s, label
+    For more details, see Notes below.
 
     Parameters
     ----------
@@ -51,10 +63,10 @@ def simple2annot(annot_path,
     .csv files parsed by this function should have the following format:
     3 columns: 'onsets_s', 'offsets_s', and 'labels`.
     There should be a header with those column names.
-    The annotation file should have the same name as the audio file that
-    it annotates, with the extension .csv added.
-    E.g., if the audio file is named 'fly1-2020-12-03.wav' then the .csv file
-    should be named 'fly1-2020-12-03.wav.csv'.
+    The annotation file should have the same name as the source file
+    (audio or spectrogram) that it annotates, with the extension .csv added.
+    E.g., if an audio file is named 'fly1-2020-12-03.wav' then the .csv file
+    that annotates it should be named 'fly1-2020-12-03.wav.csv'.
 
     The abspath and basename parameters specify how file names for audio files are saved.
     These options are useful for working with multiple copies of files and for
@@ -139,11 +151,11 @@ def simple2csv(annot_path, csv_filename, abspath=False, basename=False):
                          'information (just base filename) should be saved.')
 
     annot = simple2annot(annot_path)
-    annot2csv(annot, csv_filename, abspath=abspath, basename=basename)
+    generic.annot2csv(annot, csv_filename, abspath=abspath, basename=basename)
 
 
 meta = Meta(
-    name='simple-csv',
+    name='simple-seq',
     ext='csv',
     from_file=simple2annot,
     to_csv=simple2csv,

--- a/src/crowsetta/textgrid.py
+++ b/src/crowsetta/textgrid.py
@@ -10,8 +10,8 @@ import os
 import numpy as np
 from crowsetta._vendor.textgrid import TextGrid, IntervalTier
 
+from . import generic
 from .annotation import Annotation
-from .csv import annot2csv
 from .meta import Meta
 from .sequence import Sequence
 from .validation import validate_ext
@@ -147,7 +147,7 @@ def textgrid2csv(annot_path, csv_filename, abspath=False, basename=False):
                          'information (just base filename) should be saved.')
 
     annots = textgrid2annot(annot_path)
-    annot2csv(annots, csv_filename, abspath=abspath, basename=basename)
+    generic.annot2csv(annots, csv_filename, abspath=abspath, basename=basename)
 
 
 meta = Meta(

--- a/src/crowsetta/transcriber.py
+++ b/src/crowsetta/transcriber.py
@@ -2,8 +2,10 @@ import os
 from importlib import import_module
 import importlib.util
 
-from .csv import toannot_func_to_csv
-from . import formats
+from . import (
+    formats,
+    generic
+)
 from .meta import Meta
 
 HERE = os.path.dirname(__file__)
@@ -126,7 +128,7 @@ class Transcriber:
             if 'to_csv' not in config:
                 # default to function returned by toseq_func_to_csv()
                 # when we pass it from_file
-                self.to_csv = toannot_func_to_csv(self.from_file)
+                self.to_csv = generic.toannot_func_to_csv(self.from_file)
             elif config['to_csv'] is None:
                 self.to_csv = not_implemented
             else:

--- a/src/crowsetta/yarden.py
+++ b/src/crowsetta/yarden.py
@@ -8,11 +8,10 @@ from pathlib import Path
 import numpy as np
 from scipy.io import loadmat
 
+from . import generic
 from .annotation import Annotation
-from .csv import annot2csv
 from .meta import Meta
 from .sequence import Sequence
-from .validation import validate_ext
 
 
 def _cast_to_arr(val):
@@ -211,7 +210,7 @@ def yarden2csv(annot_path, csv_filename, abspath=False, basename=False):
                          'unclear whether absolute path should be saved or if no path '
                          'information (just base filename) should be saved.')
     annot = yarden2annot(annot_path)
-    annot2csv(annot, csv_filename, abspath=abspath, basename=basename)
+    generic.annot2csv(annot, csv_filename, abspath=abspath, basename=basename)
 
 
 meta = Meta(

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -24,9 +24,9 @@ def test_annot2csv(test_data_root,
                                 'test.csv')
     # below, set basename to True so we can easily run tests on any system without
     # worrying about where audio files are relative to root of directory tree
-    crowsetta.csv.annot2csv(annot_list,
-                            csv_filename,
-                            basename=True)
+    crowsetta.generic.annot2csv(annot_list,
+                                csv_filename,
+                                basename=True)
     assert os.path.isfile(csv_filename)
     test_rows = []
     with open(csv_filename, 'r', newline='') as csvfile:
@@ -64,7 +64,7 @@ def test_annot2csv_when_one_pair_of_onsets_and_offsets_is_None(tmp_path,
     )
     csv_filename = os.path.join(tmp_path,
                              'test_annot2csv_onset_None.csv')
-    crowsetta.csv.annot2csv(annot=annot_list, csv_filename=csv_filename)
+    crowsetta.generic.annot2csv(annot=annot_list, csv_filename=csv_filename)
 
     with open(csv_filename, 'r', newline='') as csvfile:
         reader = csv.reader(csvfile)
@@ -76,7 +76,7 @@ def test_annot2csv_when_one_pair_of_onsets_and_offsets_is_None(tmp_path,
 
 
 def test_toannot_func_to_csv_with_builtin_format(test_data_root, tmp_path):
-    notmat2csv = crowsetta.csv.toannot_func_to_csv(crowsetta.notmat.notmat2annot)
+    notmat2csv = crowsetta.generic.toannot_func_to_csv(crowsetta.notmat.notmat2annot)
     cbin_dir = test_data_root.joinpath('cbins/gy6or6/032312/')
     notmat_list = [str(path) for path in cbin_dir.glob('*.not.mat')]
     # below, sorted() so it's the same order on different platforms
@@ -106,7 +106,7 @@ def test_toannot_func_to_csv_with_builtin_format(test_data_root, tmp_path):
 def test_csv2annot(test_data_root):
     csv_filename = test_data_root.joinpath('csv/gy6or6_032312.csv')
     # convert csv to crowsetta list -- this is what we're testing
-    annot_list_from_csv = crowsetta.csv.csv2annot(csv_filename)
+    annot_list_from_csv = crowsetta.generic.csv2annot(csv_filename)
     cbin_dir = test_data_root.joinpath('cbins/gy6or6/032312/')
 
     # get what should be the same seq list from .not.mat files
@@ -128,7 +128,7 @@ def test_csv2annot_unrecognized_fields_raises(test_data_root):
         test_data_root.joinpath('csv/unrecognized_fields_in_header.csv')
     )
     with pytest.raises(ValueError):
-        crowsetta.csv.csv2annot(csv_filename=csv_filename)
+        crowsetta.generic.csv2annot(csv_filename=csv_filename)
 
 
 def test_csv2annot_missing_fields_raises(test_data_root):
@@ -136,7 +136,7 @@ def test_csv2annot_missing_fields_raises(test_data_root):
         test_data_root.joinpath('csv/missing_fields_in_header.csv')
     )
     with pytest.raises(ValueError):
-        crowsetta.csv.csv2annot(csv_filename=csv_filename)
+        crowsetta.generic.csv2annot(csv_filename=csv_filename)
 
 
 def test_csv2annot_when_one_pair_of_onsets_and_offsets_is_None(test_data_root):
@@ -145,7 +145,7 @@ def test_csv2annot_when_one_pair_of_onsets_and_offsets_is_None(test_data_root):
     csv_with_None_columns = test_data_root.joinpath(
         'csv/example_annotation_with_onset_inds_offset_inds_None.csv'
     )
-    seq = crowsetta.csv.csv2annot(csv_filename=csv_with_None_columns)
+    seq = crowsetta.generic.csv2annot(csv_filename=csv_with_None_columns)
     assert (
         seg.onset_ind is None and seg.offset_ind is None
         for a_seq in seq for seg in a_seq.segments

--- a/tests/test_phn.py
+++ b/tests/test_phn.py
@@ -112,7 +112,7 @@ def test_PHN2csv(tmp_path, PHNs):
     filenames_from_csv = []
     with open(csv_filename, 'r', newline='') as csvfile:
         reader = csv.DictReader(csvfile,
-                                fieldnames=crowsetta.csv.CSV_FIELDNAMES)
+                                fieldnames=crowsetta.generic.CSV_FIELDNAMES)
         header = next(reader)
         for row in reader:
             filenames_from_csv.append(

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -39,6 +39,13 @@ def test_notmat_to_csv(notmats, tmp_path):
     assert csv_filename.exists()
 
 
+def test_simple_seq_from_file(simple_csvs):
+    scribe = crowsetta.Transcriber(format='simple-seq')
+    for simple_csv in simple_csvs:
+        annot = scribe.from_file(annot_path=simple_csv)
+        assert type(annot) == crowsetta.Annotation
+
+
 def test_yarden_from_file(yarden_annot_mat):
     scribe = crowsetta.Transcriber(format='yarden')
     annots = scribe.from_file(annot_path=yarden_annot_mat)


### PR DESCRIPTION
renames 'simple-csv' => 'simple-seq' and 'csv' => 'generic-seq'.
With goal of eventually having 'simple-seq' work on other file formats, e.g. .txt,
and for 'csv' to be the "generic" sequence format that allow for converting between others.

- CLN: rename 'csv' format to 'generic-seq'
- rename module 'csv.py' -> 'generic.py'
- change 'name' attribute in ``Meta`` to 'generic-seq'
- add module-level docstring that briefly describes format
- change csv.annot2csv -> generic.annot2csv in birdsongrec.py
- change csv.annot2csv -> generic.annot2csv in phn.py
- change csv.annot2csv -> generic.annot2csv in notmat.py
- change csv.annot2csv -> generic.annot2csv in textgrid.py
- change csv.annot2csv -> generic.annot2csv in yarden.py
- rename tests/test_csv.py -> test_generic.py
- change 'format' entry point 'generic' -> 'generic-seq'
  in pyproject.toml
- change csv -> generic in transcriber.py
- change csv.annot2csv -> generic.annot2csv in simple.py
- import generic, not csv, in crowsetta/__init__.py
- change csv -> generic in tests/test_phn.py
- CLN: remove unused import in simple.py
- CLN: remove unused import in yarden.py
- ENH: rename 'simple-csv' format to 'simple-seq'
  - change 'name' attribute of Meta to 'simple-seq'
    in crowsetta/simple.py
  - change entry point name in pyproject.toml
  - add module-level docstring and revise `simple2annot`
    docstring in crowsetta/simple.py
- add test to make sure simple-seq works with Transcriber.from_file