### PR TITLE
DEP: add back 'csv' format, deprecated, fix #141

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,8 +47,9 @@ dev = [
 ]
 
 [project.entry-points."crowsetta.format"]
-generic-seq = 'crowsetta.generic'
 birdsong-recognition-dataset = 'crowsetta.birdsongrec'
+csv = 'crowsetta.csv'
+generic-seq = 'crowsetta.generic'
 notmat = 'crowsetta.notmat'
 phn = 'crowsetta.phn'
 textgrid = 'crowsetta.textgrid'

--- a/src/crowsetta/csv.py
+++ b/src/crowsetta/csv.py
@@ -1,0 +1,9 @@
+from .generic import annot2csv, csv2annot
+from .meta import Meta
+
+meta = Meta(
+    name='csv',
+    ext='csv',
+    from_file=csv2annot,
+    to_csv=annot2csv,
+)

--- a/src/crowsetta/transcriber.py
+++ b/src/crowsetta/transcriber.py
@@ -1,6 +1,7 @@
 import os
 from importlib import import_module
 import importlib.util
+import warnings
 
 from . import (
     formats,
@@ -86,6 +87,13 @@ class Transcriber:
                                    f'invalid keys: {extra_keys}')
 
         if format in formats._INSTALLED and config is None:
+            if format == 'csv':
+                warnings.warn(
+                    "The format 'csv' has been renamed to 'generic-seq', "
+                    "and the name 'csv' will stop working in the next version. "
+                    "Please change any usages of the name 'csv' to 'generic-seq'` now.",
+                    FutureWarning,
+                )
             voc_format_module = getattr(formats, format)
             self.from_file = voc_format_module.meta.from_file
             if hasattr(voc_format_module.meta, 'to_csv'):

--- a/tests/test_transcriber.py
+++ b/tests/test_transcriber.py
@@ -25,6 +25,25 @@ def test_birdsongrec_to_csv(tmp_path,
     assert csv_filename.exists()
 
 
+def test_csv_from_file(test_data_root):
+    with pytest.warns(FutureWarning):
+        scribe = crowsetta.Transcriber(format='csv')
+    generic_seq_csv = test_data_root.joinpath('csv/gy6or6_032312.csv')
+    annots = scribe.from_file(generic_seq_csv)
+    assert type(annots) == list
+    assert all([type(annot) == crowsetta.Annotation
+                for annot in annots])
+
+
+def test_generic_seq_from_file(test_data_root):
+    scribe = crowsetta.Transcriber(format='generic-seq')
+    generic_seq_csv = test_data_root.joinpath('csv/gy6or6_032312.csv')
+    annots = scribe.from_file(generic_seq_csv)
+    assert type(annots) == list
+    assert all([type(annot) == crowsetta.Annotation
+                for annot in annots])
+
+
 def test_notmat_from_file(notmats):
     scribe = crowsetta.Transcriber(format='notmat')
     for notmat in notmats:


### PR DESCRIPTION
adds back 'csv' as a format name for now, but `Transcriber` raises a FutureWarning when `format='csv'`, stating the name was changed to `'generic-seq'` and that `'csv'` will stop working in the next version

- add src/crowsetta/csv.py
- add 'csv' back as entry point in pyproject.toml
- add FutureWarning to transcriber when user specifies 'csv' format
- add tests for 'csv' and 'generic-seq' in test_transcriber.py